### PR TITLE
Fix typos, change latest images to specific version 1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ curl --request POST \
 
 * **URL**
 
-  `/api/getTuna/addShushi`
+  `/api/getTuna/addSushi`
 
 * **Method:**
   
@@ -199,7 +199,7 @@ curl --request POST \
 
 ``` 
 curl --request POST \
-  --url http://localhost:3000/api/addShushi \
+  --url http://localhost:3000/api/addSushi \
   --header 'content-type: application/json' \
   --data '{
 			"id":200001,

--- a/chaincode/lib/supplyChain.js
+++ b/chaincode/lib/supplyChain.js
@@ -2,7 +2,7 @@
 
 const { Contract } = require('fabric-contract-api');
 
-class SypplyChain extends Contract {
+class SupplyChain extends Contract {
 
 
   async addAsset(ctx, asset) {
@@ -18,7 +18,7 @@ class SypplyChain extends Contract {
     if (!assetAsBytes || assetAsBytes.length === 0) {
       throw new Error(`${assetId} does not exist`);
     }
-    console.log(sassetAsBytes.toString());
+    console.log(assetAsBytes.toString());
     console.info('============= END : Query asset ===========');
     return assetAsBytes.toString();
   }
@@ -58,4 +58,4 @@ class SypplyChain extends Contract {
 
 }
 
-module.exports = SypplyChain;
+module.exports = SupplyChain;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -89,7 +89,7 @@ app.get('/api/getHistorySushi/:id', async function (req, res) {
   }
 })
 
-app.get('/api/getShushi/:id', async function (req, res) {
+app.get('/api/getSushi/:id', async function (req, res) {
   try {
     const contract = await fabricNetwork.connectNetwork('connection-retailer.json', 'wallet/wallet-retailer');
     const result = await contract.evaluateTransaction('queryAsset', req.params.id.toString());
@@ -104,7 +104,7 @@ app.get('/api/getShushi/:id', async function (req, res) {
 })
 
 
-app.post('/api/addShushi', async function (req, res) {
+app.post('/api/addSushi', async function (req, res) {
   try {
     const contract = await fabricNetwork.connectNetwork('connection-manufacturer.json', 'wallet/wallet-manufacturer');
     let sushi = {

--- a/supply-network/base/peer-base.yaml
+++ b/supply-network/base/peer-base.yaml
@@ -13,7 +13,7 @@ services:
       # the following setting starts chaincode containers on the same
       # bridge network as the peers
       # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=supplynetwork_byfn
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=supply-network_byfn
       - FABRIC_LOGGING_SPEC=INFO
       #- FABRIC_LOGGING_SPEC=DEBUG
       - CORE_PEER_TLS_ENABLED=true

--- a/supply-network/scripts/start.sh
+++ b/supply-network/scripts/start.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-export IMAGE_TAG=latest
+export IMAGE_TAG=1.4.3
 
 echo "Creating containers... "
+
+# TODO This approach is hacky; instead, identify where hyperledger/fabric-ccenv is pulled and update the tag to 1.4.3
+docker pull hyperledger/fabric-ccenv:1.4.3
+docker tag hyperledger/fabric-ccenv:1.4.3 hyperledger/fabric-ccenv:latest
+
 docker-compose -f ./supply-network/docker-compose-cli.yaml up -d
 echo 
 echo "Containers started" 


### PR DESCRIPTION
Fix typos for:

* Shushi -> Sushi
* SypplyChain -> SupplyChain
* supplynetwork_byfn -> supply-network_byfn

Add specific image tags for docker images (1.4.3) instead of using `latest`.